### PR TITLE
feature(cli) Complete dummied command-line interface per doc specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+
+AllCops:
+  TargetRubyVersion: 2.4
+
+Metrics/BlockLength:
+  Max: 300
+  Include:
+    - 'test/**/*_test.rb'
+
+Metrics/ModuleLength:
+  Max: 300
+  Include:
+    - 'test/**/*_test.rb'

--- a/README.md
+++ b/README.md
@@ -1,24 +1,13 @@
 <h1>DoApiScripting</h1>
 
-- [DoApiScripting](#doapiscripting)
-  * [Installation](#installation)
-  * [Usage](#usage)
-  	  * [Help](#help)
-  	  * [All Droplets](#all-droplets)
-  	  * [All Floating IPs](#all-floating-ips)
-  	  * [Assign Floating IP](#assign-floating-ip)
-  	  * [Droplet Info](#droplet-info)
-  	  * [Power Off](#power-off)
-  	  * [Power On](#power-on)
-  	  * [Rename](#rename)
-  	  * [Shutdown](#shutdown)
-  	  * [Version](#version)
-  * [Development](#development)
-  * [Contributing](#contributing)
-    * [Contributing](#contributing)
-      * [Process](#process)
-      * [Notes on Contributing](#notes-on-contributing)
-  * [License](#license)
+- [Overview](#overview)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Development](#development)
+- [Contributing](#contributing)
+  - [Process](#process)
+  - [Notes on Contributing](#notes-on-contributing)
+- [License](#license)
 
 ## Overview
 

--- a/bin/setup-and-test.sh
+++ b/bin/setup-and-test.sh
@@ -19,7 +19,7 @@ das_setup() {
   gem install flog -v 4.6.1
   gem install license_finder -v 3.0.0
   gem install minitest-matchers -v 1.4.1
-  gem install prolog_minitest_matchers -v 0.5.3
+  gem install prolog_minitest_matchers -v 0.5.4
   gem install minitest-reporters -v 1.1.14
   gem install minitest-tagz -v 1.5.2
   gem install pry -v 0.10.4

--- a/do_api_scripting.gemspec
+++ b/do_api_scripting.gemspec
@@ -30,18 +30,19 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "1.15.1"
-  spec.add_development_dependency "rake", "~> 12.0.0"
-  spec.add_development_dependency "minitest", "5.10.2"
-
+  spec.add_dependency "dry-struct", '0.3.1'
   spec.add_dependency "excon", "0.57.1"
   spec.add_dependency "semantic_logger", '4.1.1'
+
+  spec.add_development_dependency "bundler", "1.15.1"
+  spec.add_development_dependency "rake", "12.0.0"
+  spec.add_development_dependency "minitest", "5.10.2"
 
   spec.add_development_dependency "minitest-matchers", '1.4.1'
   spec.add_development_dependency "minitest-reporters", '1.1.14'
   spec.add_development_dependency "minitest-tagz", '1.5.2'
 
-  spec.add_development_dependency "prolog_minitest_matchers", '0.5.3'
+  spec.add_development_dependency "prolog_minitest_matchers", '0.5.4'
 
   spec.add_development_dependency "awesome_print", '1.8.0'
   spec.add_development_dependency "benchmark-ips", '2.7.2'

--- a/do_api_scripting.gemspec
+++ b/do_api_scripting.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-struct", '0.3.1'
   spec.add_dependency "excon", "0.57.1"
   spec.add_dependency "semantic_logger", '4.1.1'
+  spec.add_dependency 'thor', '0.19.4'
 
   spec.add_development_dependency "bundler", "1.15.1"
   spec.add_development_dependency "rake", "12.0.0"

--- a/doc/USAGE-SPECIFICATION.md
+++ b/doc/USAGE-SPECIFICATION.md
@@ -1,5 +1,17 @@
 <h1>Usage of the 'do_api' Command</h1>
 
+- [Overview](#overview)
+- [Commands](#commands)
+  - [Help](#help)
+  - [All Droplets](#all-droplets)
+  - [All Floating IPs](#all-floating-ips)
+  - [Assign Floating IP](#assign-floating-ip)
+  - [Droplet Info](#droplet-info)
+  - [Power Off](#power-off)
+  - [Power On](#power-on)
+  - [Rename](#rename)
+  - [Shutdown](#shutdown)
+  - [Version](#version)
 # Overview
 
 The `do_api` utility has several queries and commands, which follow a fairly uniform pattern.

--- a/exe/do_api
+++ b/exe/do_api
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'do_api_scripting/cli'
+
+DoApiScripting::CLI.start

--- a/lib/do_api_scripting.rb
+++ b/lib/do_api_scripting.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'do_api_scripting/version'
+require 'do_api_scripting/cli'
 
 # Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
 module DoApiScripting

--- a/lib/do_api_scripting/cli.rb
+++ b/lib/do_api_scripting/cli.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative './cli/all_droplets'
+require_relative './cli/all_floating_ips'
+require_relative './cli/assign_floating_ip'
+require_relative './cli/info'
+require_relative './cli/power_off'
+require_relative './cli/power_on'
+require_relative './cli/rename'
+require_relative './cli/shutdown'
+require_relative './cli/version'

--- a/lib/do_api_scripting/cli/all_droplets.rb
+++ b/lib/do_api_scripting/cli/all_droplets.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'all_droplets', 'Summarise all Droplets owned by the user'
+
+    def all_droplets
+      say "Would summarise all Droplets owned by PAT #{ENV['DO_API_TOKEN']}"
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/all_floating_ips.rb
+++ b/lib/do_api_scripting/cli/all_floating_ips.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'all_floating_ips', 'Summarise all Floating IPs owned by the user'
+
+    def all_floating_ips
+      say fip_message
+    end
+
+    private
+
+    # Reek says this is a :reek:UtilityFunction. Some things don't use state.
+    def fip_message
+      parts = ['Would summarise all Floating IPs owned by PAT ', '.']
+      parts.join(ENV['DO_API_TOKEN'].to_s)
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/assign_floating_ip.rb
+++ b/lib/do_api_scripting/cli/assign_floating_ip.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'assign_floating_ip IP_ADDRESS', 'Assign a Floating IP to a Droplet'
+    method_option :"droplet-id", required: true, aliases: '-d',
+                                 desc: 'Droplet ID to report on (REQUIRED)'
+    def assign_floating_ip(ip_addr)
+      say "Would assign Droplet #{options['droplet-id']} to IP #{ip_addr}."
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/info.rb
+++ b/lib/do_api_scripting/cli/info.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'info', 'Report information about a Droplet with a specific ID'
+    method_option :"droplet-id", required: true, aliases: '-d',
+                                 desc: 'Droplet ID to report on (REQUIRED)'
+
+    def info
+      say "Would summarise Droplet #{options['droplet-id']}."
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/power_off.rb
+++ b/lib/do_api_scripting/cli/power_off.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'power_off',
+         'Forcibly power off an existing Droplet with a specific ID'
+    method_option :"droplet-id", required: true, aliases: '-d',
+                                 desc: 'Droplet ID to rename (REQUIRED)'
+
+    def power_off
+      say "Would forcibly power off Droplet #{options['droplet-id']}."
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/power_on.rb
+++ b/lib/do_api_scripting/cli/power_on.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'power_on', 'Power on an existing Droplet with a specific ID'
+    method_option :"droplet-id", required: true, aliases: '-d',
+                                 desc: 'Droplet ID to rename (REQUIRED)'
+
+    def power_on
+      say "Would power on Droplet #{options['droplet-id']}."
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/rename.rb
+++ b/lib/do_api_scripting/cli/rename.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'rename NEW_NAME', 'Rename an existing Droplet with a specific ID'
+    method_option :"droplet-id", required: true, aliases: '-d',
+                                 desc: 'Droplet ID to rename (REQUIRED)'
+    def rename(new_name)
+      say "Would rename Droplet #{options['droplet-id']} to #{new_name}."
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/shutdown.rb
+++ b/lib/do_api_scripting/cli/shutdown.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'shutdown', 'Gracefully shut down existing Droplet with a specific ID'
+    method_option :"droplet-id", required: true, aliases: '-d',
+                                 desc: 'Droplet ID to shut down (REQUIRED)'
+
+    def shutdown
+      say "Would gracefully shut down Droplet #{options['droplet-id']}."
+    end
+  end # class DoApiScripting::CLI
+end

--- a/lib/do_api_scripting/cli/version.rb
+++ b/lib/do_api_scripting/cli/version.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+require 'do_api_scripting/version'
+
+# Code to support scripting the DigitalOcean API, e.g., for use with Ansible.
+module DoApiScripting
+  # Logic to connect command-line interface to API command implementations.
+  class CLI < Thor
+    desc 'version', 'Display version information for utility'
+    def version
+      say "Version #{VERSION}"
+    end
+  end # class DoApiScripting::CLI
+end

--- a/test/do_api_scripting/cli/all_droplets_test.rb
+++ b/test/do_api_scripting/cli/all_droplets_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/all_droplets'
+
+module DoApiScripting
+  describe 'CLI "all_droplets" command' do
+    let(:out_streams) do
+      out, err = capture_io { CLI.new.all_droplets }
+      Struct.new(:err, :out).new err, out
+    end
+
+    describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+      before do
+        ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+      end
+
+      it 'produces no error output' do
+        expect(out_streams.err).must_be :empty?
+      end
+
+      it 'produces a DUMMIED message containing $DO_API_TOKEN' do
+        expr = /Would summarise all Droplets owned by PAT ([0-9A-Fa-f]{64})\n/
+        actual = out_streams.out.match(expr)
+        expect(actual[1]).must_equal ENV['DO_API_TOKEN']
+      end
+    end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+    describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+      before do
+        @old_token = ENV.delete 'DO_API_TOKEN'
+      end
+
+      after do
+        ENV['DO_API_TOKEN'] = @old_token
+      end
+
+      it 'raises an ApiKeyMissing error' do
+        skip 'No checking of DO_API_TOKEN for dummied command output'
+        # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+        error_class = RuntimeError
+        expect { out_streams }.must_raise error_class
+      end
+    end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+  end # describe 'CLI "all_droplets" command'
+end

--- a/test/do_api_scripting/cli/all_floating_ips_test.rb
+++ b/test/do_api_scripting/cli/all_floating_ips_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/all_floating_ips'
+
+module DoApiScripting
+  describe 'CLI "all_floating_ips" command' do
+    let(:out_streams) do
+      out, err = capture_io { CLI.new.all_floating_ips }
+      Struct.new(:err, :out).new err, out
+    end
+
+    describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+      before do
+        ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+      end
+
+      it 'produces no error output' do
+        expect(out_streams.err).must_be :empty?
+      end
+
+      it 'produces a DUMMIED message containing $DO_API_TOKEN' do
+        expr_str = 'Would summarise all Floating IPs owned by PAT ' \
+          "([0-9A-Fa-f]{64}).\n"
+        expr = Regexp.new expr_str
+        actual = out_streams.out.match(expr)
+        expect(actual[1]).must_equal ENV['DO_API_TOKEN']
+      end
+    end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+    describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+      before do
+        @old_token = ENV.delete 'DO_API_TOKEN'
+      end
+
+      after do
+        ENV['DO_API_TOKEN'] = @old_token
+      end
+
+      it 'raises an ApiKeyMissing error' do
+        skip 'No checking of DO_API_TOKEN for dummied command output'
+        # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+        error_class = RuntimeError
+        expect { out_streams }.must_raise error_class
+      end
+    end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+  end # describe 'CLI "all_floating_ips" command'
+end

--- a/test/do_api_scripting/cli/assign_floating_ip_test.rb
+++ b/test/do_api_scripting/cli/assign_floating_ip_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/assign_floating_ip'
+
+module DoApiScripting
+  describe 'CLI "assign_floating_ip" command' do
+    let(:cli_options) { { 'droplet-id': droplet_id } }
+    let(:droplet_id) { '87654321' }
+    let(:out_streams) do
+      out, err = capture_io { the_cli.assign_floating_ip new_ip }
+      Struct.new(:err, :out).new err, out
+    end
+    let(:the_cli) { CLI.new [], cli_options }
+
+    describe 'with a new IP address specified' do
+      let(:new_ip) { '128.256.256.1' } # NOTE: Invalid IP address, d'oh!
+
+      describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+        end
+
+        it 'produces no error output' do
+          expect(out_streams.err).must_be :empty?
+        end
+
+        it 'produces a DUMMIED message containing the Droplet ID and new IP' do
+          expr = /Would assign Droplet ([0-9A-Fa-f]{8}) to IP #{new_ip}\.\n/
+          actual = expr.match out_streams.out
+          expect(actual[1]).must_equal droplet_id
+        end
+      end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+      describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          @old_token = ENV.delete 'DO_API_TOKEN'
+        end
+
+        after do
+          ENV['DO_API_TOKEN'] = @old_token
+        end
+
+        it 'raises an ApiKeyMissing error' do
+          skip 'No checking of DO_API_TOKEN for dummied command output'
+          # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+          error_class = RuntimeError
+          expect { out_streams }.must_raise error_class
+        end
+      end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+    end # describe 'with a new IP address specified'
+
+    describe 'with a new IP address erroneously omitted' do
+      let(:new_ip) { nil } # oops...
+
+      it 'reports being called with no arguments' do
+        expected = [
+          %w[ERROR: "do_api assign_floating_ip" was called with no
+             arguments].join(' '),
+          'Usage: "do_api assign_floating_ip IP_ADDRESS -d, ' \
+            '--droplet-id=DROPLET-ID"'
+        ]
+        skip 'No checking of new IP address for dummied command output'
+        lines = out_streams.err.lines
+        expect(lines).must_equal expected
+      end
+    end # describe 'with a new IP address erroneously omitted'
+  end # describe 'CLI "assign_floating_ip" command'
+end

--- a/test/do_api_scripting/cli/help_test.rb
+++ b/test/do_api_scripting/cli/help_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli'
+
+module DoApiScripting
+  VALID_COMMANDS = {
+    all_droplets: false,
+    all_floating_ips: false,
+    assign_floating_ip: true,
+    help: false,
+    info: true,
+    power_off: true,
+    power_on: true,
+    rename: true,
+    shutdown: true,
+    version: false
+  }.freeze
+
+  describe 'CLI "help" command' do
+    let(:described_class) { CLI }
+    let(:valid_commands) { VALID_COMMANDS.keys.map(&:to_s) }
+
+    describe 'for all commands' do
+      let(:out_streams) do
+        out, err = capture_io do
+          described_class.new.help
+        end
+        Struct.new(:err, :out).new err, out
+      end
+
+      it 'produces no error output' do
+        expect(out_streams.err).must_be :empty?
+      end
+
+      describe 'produces standard output that' do
+        let(:command_help) { out_lines[1..-2] }
+        let(:out_lines) { out_streams.out.lines }
+
+        it 'starts with a "Commands:" line' do
+          expect(out_lines.first).must_equal "Commands:\n"
+        end
+
+        it 'ends with an empty line' do
+          expect(out_lines.last).must_equal "\n"
+        end
+
+        it 'describes all commands' do
+          actual_commands = command_help.map { |str| str.split[1] }
+          expect(actual_commands).must_equal valid_commands
+        end
+
+        describe 'for each command described' do
+          it 'includes usage and a description, separated by a "#" character' do
+            errors = command_help.reject { |str| str.split('#').length == 2 }
+            expect(errors).must_be :empty?
+          end
+        end # describe "for each command described"
+      end # describe 'produces standard output that'
+    end # describe 'for all commands'
+
+    describe 'for the command' do
+      let(:out_streams) do
+        pr = proc do |command|
+          out, err = capture_io do
+            described_class.new.help command
+          end
+          Struct.new(:err, :out).new err, out
+        end
+        ret = {}
+        valid_commands.each { |command| ret[command.to_sym] = pr.call command }
+        ret
+      end
+
+      VALID_COMMANDS.each do |command, requires_droplet|
+        describe command do
+          let(:os) { out_streams[command.to_sym] }
+
+          it 'produces no error output' do
+            expect(os.err).must_be :empty?
+          end
+
+          it 'produces at least four lines of standard output' do
+            expect(os.out.lines.count).wont_be :<, 4
+          end
+
+          describe 'produces standard output such that' do
+            it 'the first line reads "Usage:" with a trailing newline' do
+              expect(os.out.lines.first).must_equal "Usage:\n"
+            end
+
+            it 'the second line describes the command syntax' do
+              words = os.out.lines[1].split
+              expect(words[1]).must_equal command.to_s
+            end
+
+            it 'the third line contains only a newline' do
+              expect(os.out.lines[2]).must_equal "\n"
+            end
+
+            if requires_droplet
+              it 'requires a --droplet option' do
+                expect(os.out.lines[3]).must_equal "Options:\n"
+                last_line_parts = os.out.lines[4].split('#').map(&:strip)
+                option_text = '-d, --droplet-id=DROPLET-ID'
+                expect(last_line_parts.first).must_equal option_text
+                match_ex = /Droplet ID to (.+?) \(REQUIRED\)/
+                expect(last_line_parts.last).must_match match_ex
+              end
+
+              it 'has an empty sixth line' do
+                expect(os.out.lines[5]).must_equal "\n"
+              end
+            else
+              it 'does not require any options' do
+                expect(os.out.lines[3]).wont_equal "Options:\n"
+              end
+
+              it 'the fourth line is not a blank line' do
+                expect(os.out.lines[3]).wont_equal "\n"
+              end
+            end # if requires_droplet
+          end # describe 'produces standard output such that'
+        end # describe command
+      end # VALID_COMMANDS.each
+    end # describe 'for the command'
+  end # describe 'CLI "help" command'
+end

--- a/test/do_api_scripting/cli/info_test.rb
+++ b/test/do_api_scripting/cli/info_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/info'
+
+module DoApiScripting
+  describe 'CLI "info" command' do
+    let(:cli_options) { { 'droplet-id': droplet_id } }
+    let(:out_streams) do
+      out, err = capture_io { the_cli.info }
+      Struct.new(:err, :out).new err, out
+    end
+
+    describe 'with a Droplet ID specified' do
+      let(:droplet_id) { '87654321' }
+      let(:the_cli) { CLI.new [], cli_options }
+
+      describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+        end
+
+        it 'produces no error output' do
+          expect(out_streams.err).must_be :empty?
+        end
+
+        it 'produces a DUMMIED message containing the Droplet ID' do
+          expr = /Would summarise Droplet #{droplet_id}\.\n/
+          expect(out_streams.out).must_match expr
+        end
+      end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+      describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          @old_token = ENV.delete 'DO_API_TOKEN'
+        end
+
+        after do
+          ENV['DO_API_TOKEN'] = @old_token
+        end
+
+        it 'raises an ApiKeyMissing error' do
+          skip 'No checking of DO_API_TOKEN for dummied command output'
+          # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+          error_class = RuntimeError
+          expect { out_streams }.must_raise error_class
+        end
+      end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+    end # describe 'with a Droplet ID specified'
+
+    describe 'with a Droplet ID inadvertently omitted' do
+      let(:droplet_id) { nil }
+      let(:the_cli) { CLI.new }
+
+      it 'reports being called with no arguments' do
+        expected = [
+          %w[ERROR: "do_api info" was called with no
+             arguments].join(' '),
+          'Usage: "do_api info IP_ADDRESS -d, --droplet-id=DROPLET-ID"'
+        ]
+        skip 'No checking of Droplet ID for dummied command output'
+        lines = out_streams.err.lines
+        expect(lines).must_equal expected
+      end
+    end # describe 'with a Droplet ID inadvertently omitted'
+  end # describe 'CLI "info" command'
+end

--- a/test/do_api_scripting/cli/power_off_test.rb
+++ b/test/do_api_scripting/cli/power_off_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/power_off'
+
+module DoApiScripting
+  describe 'CLI "power off" command' do
+    let(:cli_options) { { 'droplet-id': droplet_id } }
+    let(:out_streams) do
+      out, err = capture_io { the_cli.power_off }
+      Struct.new(:err, :out).new err, out
+    end
+
+    describe 'with a Droplet ID specified' do
+      let(:droplet_id) { '87654321' }
+      let(:the_cli) { CLI.new [], cli_options }
+
+      describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+        end
+
+        it 'produces no error output' do
+          expect(out_streams.err).must_be :empty?
+        end
+
+        it 'produces a DUMMIED message containing the Droplet ID' do
+          expr = /Would forcibly power off Droplet #{droplet_id}\.\n/
+          expect(out_streams.out).must_match expr
+        end
+      end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+      describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          @old_token = ENV.delete 'DO_API_TOKEN'
+        end
+
+        after do
+          ENV['DO_API_TOKEN'] = @old_token
+        end
+
+        it 'raises an ApiKeyMissing error' do
+          skip 'No checking of DO_API_TOKEN for dummied command output'
+          # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+          error_class = RuntimeError
+          expect { out_streams }.must_raise error_class
+        end
+      end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+    end # describe 'with a Droplet ID specified'
+
+    describe 'with a Droplet ID inadvertently omitted' do
+      let(:droplet_id) { nil }
+      let(:the_cli) { CLI.new }
+
+      it 'reports being called with no arguments' do
+        expected = [
+          %w[ERROR: "do_api power_off" was called with no
+             arguments].join(' '),
+          'Usage: "do_api power_off IP_ADDRESS -d, --droplet-id=DROPLET-ID"'
+        ]
+        skip 'No checking of Droplet ID for dummied command output'
+        lines = out_streams.err.lines
+        expect(lines).must_equal expected
+      end
+    end # describe 'with a Droplet ID inadvertently omitted'
+  end # describe 'CLI "power_off" command'
+end

--- a/test/do_api_scripting/cli/power_on_test.rb
+++ b/test/do_api_scripting/cli/power_on_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/power_on'
+
+module DoApiScripting
+  describe 'CLI "power on" command' do
+    let(:cli_options) { { 'droplet-id': droplet_id } }
+    let(:out_streams) do
+      out, err = capture_io { the_cli.power_on }
+      Struct.new(:err, :out).new err, out
+    end
+
+    describe 'with a Droplet ID specified' do
+      let(:droplet_id) { '87654321' }
+      let(:the_cli) { CLI.new [], cli_options }
+
+      describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+        end
+
+        it 'produces no error output' do
+          expect(out_streams.err).must_be :empty?
+        end
+
+        it 'produces a DUMMIED message containing the Droplet ID' do
+          expr = /Would power on Droplet #{droplet_id}\.\n/
+          expect(out_streams.out).must_match expr
+        end
+      end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+      describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          @old_token = ENV.delete 'DO_API_TOKEN'
+        end
+
+        after do
+          ENV['DO_API_TOKEN'] = @old_token
+        end
+
+        it 'raises an ApiKeyMissing error' do
+          skip 'No checking of DO_API_TOKEN for dummied command output'
+          # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+          error_class = RuntimeError
+          expect { out_streams }.must_raise error_class
+        end
+      end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+    end # describe 'with a Droplet ID specified'
+
+    describe 'with a Droplet ID inadvertently omitted' do
+      let(:droplet_id) { nil }
+      let(:the_cli) { CLI.new }
+
+      it 'reports being called with no arguments' do
+        expected = [
+          %w[ERROR: "do_api power_on" was called with no
+             arguments].join(' '),
+          'Usage: "do_api power_off IP_ADDRESS -d, --droplet-id=DROPLET-ID"'
+        ]
+        skip 'No checking of Droplet ID for dummied command output'
+        lines = out_streams.err.lines
+        expect(lines).must_equal expected
+      end
+    end # describe 'with a Droplet ID inadvertently omitted'
+  end # describe 'CLI "power_on" command'
+end

--- a/test/do_api_scripting/cli/rename_test.rb
+++ b/test/do_api_scripting/cli/rename_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/rename'
+
+module DoApiScripting
+  describe 'CLI "rename" command' do
+    let(:cli_options) { { 'droplet-id': droplet_id } }
+    let(:droplet_id) { '87654321' }
+    let(:out_streams) do
+      out, err = capture_io { the_cli.rename new_name }
+      Struct.new(:err, :out).new err, out
+    end
+    let(:the_cli) { CLI.new [], cli_options }
+
+    describe 'with a new name specified' do
+      let(:new_name) { 'new-droplet-name' }
+
+      describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+        end
+
+        it 'produces no error output' do
+          expect(out_streams.err).must_be :empty?
+        end
+
+        it 'produces a DUMMIED message with the Droplet ID and new name' do
+          expr = /Would rename Droplet ([0-9A-Fa-f]{8}) to #{new_name}\.\n/
+          actual = expr.match out_streams.out
+          expect(actual[1]).must_equal droplet_id
+        end
+      end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+      describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          @old_token = ENV.delete 'DO_API_TOKEN'
+        end
+
+        after do
+          ENV['DO_API_TOKEN'] = @old_token
+        end
+
+        it 'raises an ApiKeyMissing error' do
+          skip 'No checking of DO_API_TOKEN for dummied command output'
+          # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+          error_class = RuntimeError
+          expect { out_streams }.must_raise error_class
+        end
+      end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+    end # describe 'with a new name specified'
+
+    describe 'with the new name erroneously omitted' do
+      let(:new_name) { nil } # oops...
+
+      it 'reports being called with no arguments' do
+        expected = [
+          %w[ERROR: "do_api rename" was called with no
+             arguments].join(' '),
+          'Usage: "do_api rename NEW_NAME -d, ' \
+            '--droplet-id=DROPLET-ID"'
+        ]
+        skip 'No checking of new name for dummied command output'
+        lines = out_streams.err.lines
+        expect(lines).must_equal expected
+      end
+    end # describe 'with the new name erroneously omitted'
+  end # describe 'CLI "rename" command'
+end

--- a/test/do_api_scripting/cli/shutdown_test.rb
+++ b/test/do_api_scripting/cli/shutdown_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/shutdown'
+
+module DoApiScripting
+  describe 'CLI "shutdown" command' do
+    let(:cli_options) { { 'droplet-id': droplet_id } }
+    let(:out_streams) do
+      out, err = capture_io { the_cli.shutdown }
+      Struct.new(:err, :out).new err, out
+    end
+
+    describe 'with a Droplet ID specified' do
+      let(:droplet_id) { '87654321' }
+      let(:the_cli) { CLI.new [], cli_options }
+
+      describe 'with a value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          ENV['DO_API_TOKEN'] ||= '0123456789abcdef' * 4 # NOTE: DUMMY VALUE
+        end
+
+        it 'produces no error output' do
+          expect(out_streams.err).must_be :empty?
+        end
+
+        it 'produces a DUMMIED message containing the Droplet ID' do
+          expr = /Would gracefully shut down Droplet #{droplet_id}\.\n/
+          expect(out_streams.out).must_match expr
+        end
+      end # describe 'with a value defined for ENV["DO_API_TOKEN"]'
+
+      describe 'with no value defined for ENV["DO_API_TOKEN"]' do
+        before do
+          @old_token = ENV.delete 'DO_API_TOKEN'
+        end
+
+        after do
+          ENV['DO_API_TOKEN'] = @old_token
+        end
+
+        it 'raises an ApiKeyMissing error' do
+          skip 'No checking of DO_API_TOKEN for dummied command output'
+          # error_class = DoApiScripting::CLIConfig::ApiKeyMissing
+          error_class = RuntimeError
+          expect { out_streams }.must_raise error_class
+        end
+      end # describe 'with no value defined for ENV["DO_API_TOKEN"]'
+    end # describe 'with a Droplet ID specified'
+
+    describe 'with a Droplet ID inadvertently omitted' do
+      let(:droplet_id) { nil }
+      let(:the_cli) { CLI.new }
+
+      it 'reports being called with no arguments' do
+        expected = [
+          %w[ERROR: "do_api shutdown" was called with no
+             arguments].join(' '),
+          'Usage: "do_api shutdown -d, --droplet-id=DROPLET-ID"'
+        ]
+        skip 'No checking of Droplet ID for dummied command output'
+        lines = out_streams.err.lines
+        expect(lines).must_equal expected
+      end
+    end # describe 'with a Droplet ID inadvertently omitted'
+  end # describe 'CLI "shutdown" command'
+end

--- a/test/do_api_scripting/cli/version_test.rb
+++ b/test/do_api_scripting/cli/version_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli/version'
+require 'do_api_scripting/version'
+
+module DoApiScripting
+  describe 'CLI "version" command' do
+    let(:out_streams) do
+      out, err = capture_io { CLI.new.version }
+      Struct.new(:err, :out).new err, out
+    end
+
+    it 'produces no error output' do
+      expect(out_streams.err).must_be :empty?
+    end
+
+    it 'produces a message with the version identifier' do
+      expr = /^Version (.+?)\n$/
+      actual = out_streams.out.match(expr)
+      expect(actual[1]).must_equal VERSION
+    end
+  end # describe 'CLI "version" command'
+end

--- a/test/do_api_scripting/cli_test.rb
+++ b/test/do_api_scripting/cli_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'do_api_scripting/cli'
+
+module DoApiScripting
+  describe 'CLI' do
+    it 'uses "help" as the default command' do
+      expect(CLI.default_command).must_equal 'help'
+    end
+  end # describe 'CLI'
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,7 +39,7 @@ end
 #   CodeClimate.TestReporter.start
 # end
 
-require 'minitest/autorun' # harmless if already required
+require 'minitest/autorun'
 require 'minitest/reporters'
 require 'prolog_minitest_matchers'
 require 'minitest/tagz'


### PR DESCRIPTION
Our first step towards closing Issue #1 and releasing Version 0.9.0 of the utility Gem is to implement a Thor-based CLI that simply produces placeholder text rather than performing any API actions, while performing basic command-line syntax checks. This follows the interface specified by the `USAGE-SPECIFICATION.md` file in the `doc` directory.

With this done, we can start iterating individual command implementations while maintaining a "completely demoable" CLI.
